### PR TITLE
Potential fix for code scanning alert no. 7: Server-side request forgery

### DIFF
--- a/web.js
+++ b/web.js
@@ -511,7 +511,19 @@ app.get("/api/invites/:code", cors(), async (req, res) => {
   const inviteCode = req.params.code
     .replace(".gg", "")
     .replace("discord.gg/", "")
-    .replace("discord.com/invite/","");
+    .replace("discord.com/invite/","")
+    .trim();
+
+  // Validate invite code to prevent misuse in the outgoing request URL
+  // Allow only typical Discord invite characters and enforce a reasonable length.
+  const inviteCodePattern = /^[A-Za-z0-9_-]{1,32}$/;
+  if (!inviteCodePattern.test(inviteCode)) {
+    return res.status(400).json({
+      status: 400,
+      message: "Invalid invite code format",
+      match: false,
+    });
+  }
 
   try {
     const response = await fetch(


### PR DESCRIPTION
Potential fix for [https://github.com/sakura-talk-kingdum/sakurabot/security/code-scanning/7](https://github.com/sakura-talk-kingdum/sakurabot/security/code-scanning/7)

General approach: When building outgoing URLs from user input, constrain that input to a strict, allow-listed format and ensure it cannot affect the hostname, protocol, or unintended path/query segments. For IDs or codes, validate them against a whitelist of allowed characters and a reasonable length, and reject anything that does not match.

Concrete fix here:

1. After normalizing `inviteCode` from `req.params.code`, validate it against a strict regular expression that only allows typical Discord invite code characters (e.g., letters, numbers, and `-`/`_`) and enforce a sane length (Discord invites are usually 2–32 chars; we can choose a safe bound like 1–32).
2. If the validation fails, immediately return a 400 response (bad request) instead of making the outbound `fetch` call.
3. Optionally trim whitespace as part of normalization.

This keeps functionality the same for legitimate invite codes while blocking any attempt to inject unusual characters that might confuse URL parsing or upstream systems. All changes are localized to the `/api/invites/:code` handler in `web.js`; no new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
