### PR TITLE
Potential fix for code scanning alert no. 6: Missing CSRF middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "chart.js": "^4.4.1",
     "chartjs-node-canvas": "^5.0.0",
     "pidusage": "^3.0.2",
-    "systeminformation": "^5.27.14"
+    "systeminformation": "^5.27.14",
+    "csurf": "^1.11.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.22"

--- a/web.js
+++ b/web.js
@@ -9,11 +9,18 @@ import { supabase } from "./db.js";
 import { shardState } from "./index.js";
 import { handleOAuthCallback, client, voiceStates } from './bot.js';
 import cors from 'cors';
+import csurf from 'csurf';
 
 const app = express();
 app.use(express.json());
 app.use(bodyParser.urlencoded({ extended: true }))
 app.use(cookieParser());
+
+// CSRF protection using cookies. This protects routes under /admins and /gachas.
+const csrfProtection = csurf({ cookie: true });
+app.use('/admins', csrfProtection);
+app.use('/gachas', csrfProtection);
+
 const PORT = process.env.PORT || 3000;
 
 /* =====================
@@ -353,6 +360,11 @@ app.get("/admins/callback", cors(), async (req, res) => {
     secure: true,
     sameSite: "lax",
     maxAge: 1000 * 60 * 60 * 24,
+// CSRF token endpoint for clients (e.g., frontend) to fetch the token.
+app.get('/csrf-token', cors({ origin: ['https://bot.sakurahp.f5.si'], credentials: true }), (req, res) => {
+  res.json({ csrfToken: req.csrfToken() });
+});
+
   });
 
   res.redirect("/admins");


### PR DESCRIPTION
Potential fix for [https://github.com/sakura-talk-kingdum/sakurabot/security/code-scanning/6](https://github.com/sakura-talk-kingdum/sakurabot/security/code-scanning/6)

In general, the correct fix is to add a CSRF protection middleware that ties a secret token to the user’s session or cookies and requires that token to be sent with every state‑changing request (POST, PATCH, DELETE, etc.). For Express, a common approach is to use `csurf` (or `lusca.csrf`) together with `cookie-parser` or session middleware, and to expose the token to clients so that it can be sent back via a header or form field. This middleware should be wired into the middleware chain before any protected handlers that rely on cookies for authentication.

In this specific file (`web.js`), we should (1) import a CSRF middleware, (2) configure it after `cookieParser()` is applied and before the routes that need protection, and (3) expose the CSRF token on a safe endpoint so that front‑end code on `https://bot.sakurahp.f5.si` can fetch it and include it in subsequent mutating requests via a header such as `X-CSRF-Token`. To minimize behavior changes, we can scope the CSRF middleware to the relevant route groups (the admin and `/gachas` routes) rather than all routes, and we’ll configure it in “cookie mode” so it uses a signed cookie to track the secret, which fits with the existing use of `cookieParser`. Concretely, near the top of `web.js` we add an import for `csurf`, define `const csrfProtection = csurf({ cookie: true });`, and then use `app.use('/admins', csrfProtection)` and `app.use('/gachas', csrfProtection)` (or a single `app.use(csrfProtection)` if acceptable). We’ll also add a lightweight endpoint like `GET /csrf-token` that returns `req.csrfToken()` in JSON so frontends can obtain the token, without changing the logic of existing handlers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
