### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   # 1. 普通にコードをプッシュしたとき（package.json をいじってないとき用）
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/sakura-talk-kingdum/sakurabot/security/code-scanning/1](https://github.com/sakura-talk-kingdum/sakurabot/security/code-scanning/1)

In general, to fix this class of issue you explicitly declare a `permissions` block in the workflow (at the top level or per job) that grants only the scopes actually required. For a straightforward CI workflow that just checks out code and runs Node.js builds/tests, `contents: read` is typically sufficient, because the workflow never needs to write to the repository, issues, or pull requests.

The best fix here, without changing existing functionality, is to add a root‑level `permissions` block just under the `name: Node.js CI` line. This way, all jobs (currently just `build`) inherit the restricted permissions. Given the current steps (`actions/checkout`, `actions/setup-node`, `npm ci`, `npm run build`, `npm test`), only read access to repository contents is needed. We therefore set:

```yaml
permissions:
  contents: read
```

No other files or imports are needed; this is purely a YAML configuration change within `.github/workflows/node.js.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
