### PR TITLE
Potential fix for code scanning alert no. 12: Server-side request forgery

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1,6 +1,7 @@
 // bot.js
 import crypto from 'crypto';
 import fetch from 'node-fetch';
+import net from 'net';
 import {
   Client,
   GatewayIntentBits,
@@ -181,6 +182,12 @@ function isGlobalIP(ip) {
   return true;
 }
 
+function isValidIP(ip) {
+  if (!ip) return false;
+  // Use Node's built-in IP validation to ensure `ip` is a real IPv4/IPv6 address
+  return net.isIP(ip) !== 0;
+}
+
 function extractGlobalIP(ipString) {
   if (!ipString) return null;
 
@@ -199,7 +206,8 @@ function extractGlobalIP(ipString) {
    VPN CHECK
 ===================== */
 async function checkVPN(ip) {
-  if (!isGlobalIP(ip)) return false;
+  // Only proceed if the provided value is a syntactically valid, global IP address
+  if (!isValidIP(ip) || !isGlobalIP(ip)) return false;
 
   try {
     const res = await fetch(


### PR DESCRIPTION
Potential fix for [https://github.com/sakura-talk-kingdum/sakurabot/security/code-scanning/12](https://github.com/sakura-talk-kingdum/sakurabot/security/code-scanning/12)

General approach: Ensure the user-controlled value (`ip`) is strictly validated and normalized before being interpolated into the VPN API URL. For SSRF mitigation in this context, the key is to guarantee that the “IP” used in the URL is actually a valid IP address (v4 or v6) and not an arbitrary string containing path separators or other metacharacters. Once normalized, use that safe value in the URL. Since the domain is fixed, this validation is sufficient to address the CodeQL concern without changing functionality.

Concrete fix for this file:

1. Add an IP validation helper using Node’s standard library `net` (a well-known, built‑in module) to check that a string is a valid IPv4 or IPv6 address.
2. Use this helper in `checkVPN` so that it immediately returns `false` (meaning “not VPN / don’t block”) if the `ip` provided is not a syntactically valid IP address.
3. Only construct and call `fetch` if the IP is valid. This breaks the tainted-data flow into the URL because the value must pass a strong syntactic validation first.
4. Keep all other behavior the same: still rely on `isGlobalIP` to filter private/local addresses, still treat VPN API errors as “safe side” (return `true`).

Specific changes:

- In `bot.js`, add `import net from 'net';` alongside the other imports at the top.
- In the UTIL section, add a helper `function isValidIP(ip) { return net.isIP(ip) !== 0; }`.
- Update `checkVPN(ip)` to:
  - First ensure `ip` is truthy and `isValidIP(ip)` and `isGlobalIP(ip)`; otherwise return `false` without making any external request.
  - Use the validated `ip` when building the URL for `fetch`.

This preserves existing semantics for all valid, global IPs while preventing arbitrary strings from flowing into the URL path.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
