### PR TITLE
Potential fix for code scanning alert no. 15: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "chartjs-node-canvas": "^5.0.0",
     "pidusage": "^3.0.2",
     "systeminformation": "^5.30.8",
-    "csurf": "^1.11.0"
+    "csurf": "^1.11.0",
+    "express-rate-limit": "^8.3.2"
   },
   "devDependencies": {
     "nodemon": "^2.0.22"

--- a/web.js
+++ b/web.js
@@ -10,8 +10,15 @@ import { shardState } from "./index.js";
 import { handleOAuthCallback, client, voiceStates } from './bot.js';
 import cors from 'cors';
 import csurf from 'csurf';
+import rateLimit from 'express-rate-limit';
 
 const app = express();
+const oauthCallbackLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10, // max 10 callback requests per IP per window
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 app.use(express.json());
 app.use(bodyParser.urlencoded({ extended: true }))
 app.use(cookieParser());
@@ -300,7 +307,7 @@ app.get('/', cors(), (req, res) => {
 
 // コールバック
 // client は Discord.js で初期化したインスタンス名に合わせてください
-app.get('/auth/callback', cors(), (req, res) => {
+app.get('/auth/callback', cors(), oauthCallbackLimiter, (req, res) => {
     handleOAuthCallback(req, res, client); 
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/sakura-talk-kingdum/sakurabot/security/code-scanning/15](https://github.com/sakura-talk-kingdum/sakurabot/security/code-scanning/15)

Add an Express rate-limiting middleware and apply it to the `/auth/callback` route (or globally). The least invasive, functionality-preserving fix is to add a dedicated limiter for the callback endpoint so only this sensitive route is throttled.

**Best single fix in `web.js`:**
1. Import `express-rate-limit`.
2. Define a limiter (for example, 10 requests per 15 minutes per IP) near app initialization.
3. Insert that limiter in the `/auth/callback` route middleware chain before the handler.

This addresses all listed alert variants at the same location because they all refer to the same unthrottled callback handler call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
